### PR TITLE
Duplicate verse numbers

### DIFF
--- a/Adhoc scripts/nbv21_json_to_usx.py
+++ b/Adhoc scripts/nbv21_json_to_usx.py
@@ -18,11 +18,9 @@ def run(currentContent, xmlElement):
     if isinstance(currentContent, str):
         currentContent = html.escape(currentContent)
 
-        if len(xmlElement) == 0:
-            xmlElement.text = currentContent if xmlElement.text == None else xmlElement.text + currentContent
-        else:
-             target = list(xmlElement.iter())[-1]
-             target.tail = currentContent if target.tail == None else target.tail + currentContent
+        if len(xmlElement) != 0:
+            target = list(xmlElement.iter())[-1]
+            target.tail = currentContent if target.tail == None else target.tail + currentContent
     elif isinstance(currentContent, list):
         for el in currentContent:
             run(el, xmlElement)


### PR DESCRIPTION
Originally the code will put the actual verse number as text content in the generated `usx` files. For example given the following text:
> [1] In het begin schiep God de hemel en de aarde. [2] De aarde was nog woest en doods, en duisternis lag over de oervloed, maar Gods geest zweefde over het water.

The actual output would be:

> [1] 1 In het begin schiep God de hemel en de aarde. [2] 2 De aarde was nog woest en doods, en duisternis lag over de oervloed, maar Gods geest zweefde over het water.

Notice the duplicate verse numbers. This tiny code modification fixes it.

